### PR TITLE
Setup iBus

### DIFF
--- a/roles/ibus/tasks/main.yml
+++ b/roles/ibus/tasks/main.yml
@@ -19,32 +19,32 @@
   vars:
     dconf_key: /org/gnome/settings-daemon/plugins/media-keys/custom-keybindings
     dconf_dir: /org/gnome/settings-daemon/plugins/media-keys/custom-keybindings
+    keybindings:
+      - name: ibus-mozc-on
+        schemas:
+          - key: name
+            value: ibus mozc on
+          - key: command
+            value: ibus engine 'mozc-jp'
+          - key: binding
+            value: <SUPER>j
+      - name: ibus-mozc-off
+        schemas:
+          - key: name
+            value: ibus mozc off
+          - key: command
+            value: ibus engine 'xkb:us::eng'
+          - key: binding
+            value: <SUPER>e
   block:
-    - name: add keybinding to turn on ja
+    - name: add keybindings to turn on/off ja
       dconf:
-        key: "{{ dconf_dir }}/ibus-mozc-on/{{ item.key }}"
-        value: "{{ item.value | to_json }}"
+        key: "{{ dconf_dir }}/{{ item.0.name }}/{{ item.1.key }}"
+        value: "{{ item.1.value | to_json }}"
+      with_subelements:
+        - "{{ keybindings }}"
+        - schemas # inner loop key
       changed_when: no
-      with_items:
-        - key: name
-          value: ibus mozc on
-        - key: command
-          value: ibus engine 'mozc-jp'
-        - key: binding
-          value: <SUPER>j
-
-    - name: add keybinding to turn off ja
-      dconf:
-        key: "{{ dconf_dir }}/ibus-mozc-off/{{ item.key }}"
-        value: "{{ item.value | to_json }}"
-      changed_when: no
-      with_items:
-        - key: name
-          value: ibus mozc off
-        - key: command
-          value: ibus engine 'xkb:us::eng'
-        - key: binding
-          value: <SUPER>e
 
     - name: read custom keybindings
       dconf:

--- a/roles/ibus/tasks/main.yml
+++ b/roles/ibus/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+
+- name: install iBus with Mozc
+  become: yes
+  block:
+    - name: install iBus
+      package:
+        name: ibus
+
+    - name: install iBus Mozc
+      package:
+        name: ibus-mozc
+  rescue:
+    - name: skip become
+      debug:
+        msg: skip install

--- a/roles/ibus/tasks/main.yml
+++ b/roles/ibus/tasks/main.yml
@@ -17,6 +17,7 @@
 
 - name: add keybindings to on/off ja
   vars:
+    dconf_key: /org/gnome/settings-daemon/plugins/media-keys/custom-keybindings
     dconf_dir: /org/gnome/settings-daemon/plugins/media-keys/custom-keybindings
   block:
     - name: add keybinding to turn on ja
@@ -45,7 +46,20 @@
         - key: binding
           value: <SUPER>e
 
+    - name: read custom keybindings
+      dconf:
+        key: "{{ dconf_key }}"
+        state: read
+      register: dconf_read
+
     - name: register custom keybindings
       dconf:
-        key: "{{ dconf_dir }}"
-        value: "['{{ dconf_dir }}/ibus-mozc-on/', '{{ dconf_dir }}/ibus-mozc-off/']"
+        key: "{{ dconf_key }}"
+        value: "{{ merged }}"
+      vars:
+        current: "{{ dconf_read.value | from_yaml | default([], true) }}"
+        adding:
+          - "{{ dconf_dir }}/ibus-mozc-on/"
+          - "{{ dconf_dir }}/ibus-mozc-off/"
+        merged: "{{ current | union(adding) }}"
+      changed_when: merged | difference(current)

--- a/roles/ibus/tasks/main.yml
+++ b/roles/ibus/tasks/main.yml
@@ -14,3 +14,38 @@
     - name: skip become
       debug:
         msg: skip install
+
+- name: add keybindings to on/off ja
+  vars:
+    dconf_dir: /org/gnome/settings-daemon/plugins/media-keys/custom-keybindings
+  block:
+    - name: add keybinding to turn on ja
+      dconf:
+        key: "{{ dconf_dir }}/ibus-mozc-on/{{ item.key }}"
+        value: "{{ item.value | to_json }}"
+      changed_when: no
+      with_items:
+        - key: name
+          value: ibus mozc on
+        - key: command
+          value: ibus engine 'mozc-jp'
+        - key: binding
+          value: <SUPER>j
+
+    - name: add keybinding to turn off ja
+      dconf:
+        key: "{{ dconf_dir }}/ibus-mozc-off/{{ item.key }}"
+        value: "{{ item.value | to_json }}"
+      changed_when: no
+      with_items:
+        - key: name
+          value: ibus mozc off
+        - key: command
+          value: ibus engine 'xkb:us::eng'
+        - key: binding
+          value: <SUPER>e
+
+    - name: register custom keybindings
+      dconf:
+        key: "{{ dconf_dir }}"
+        value: "['{{ dconf_dir }}/ibus-mozc-on/', '{{ dconf_dir }}/ibus-mozc-off/']"

--- a/site.yml
+++ b/site.yml
@@ -23,10 +23,6 @@
         - user
         - desktop
 
-    - role: ibus
-      tags:
-        - user
-
     - role: fcitx
       become: yes
       tags:

--- a/site.yml
+++ b/site.yml
@@ -23,6 +23,10 @@
         - user
         - desktop
 
+    - role: ibus
+      tags:
+        - user
+
     - role: fcitx
       become: yes
       tags:


### PR DESCRIPTION
# iBus 設定
意外に行けた

## Changes
- add ibus on/off key

## test
~iBus ありでのテストはまだ~
~Super key 単体では無効と表示されるが未試験~
super key 単体は無理だが、機能は正常

## 既知の問題
GTKじゃないアプリなどは、 key-binding を奪ってくる（chrome, IntelliJ IDEA）。
ただ global hotkey は有効という２重状態

さらに Ubuntu 17 の GNOME 追随して来ない

## Ref
- https://qiita.com/ka_/items/dad955fe7423318b7dae
- https://askubuntu.com/questions/597395/how-to-set-custom-keyboard-shortcuts-from-terminal

### loop
- http://docs.ansible.com/ansible/latest/playbooks_loops.html#looping-over-subelements