### PR TITLE
Fix anyenv role on shell env

### DIFF
--- a/roles/anyenv/defaults/main.yml
+++ b/roles/anyenv/defaults/main.yml
@@ -1,4 +1,4 @@
-anyenv_root: ~/.anyenv
+anyenv_root: "{{ ansible_env.HOME }}/.anyenv"
 
 python_version: anaconda3-5.0.1
 python2_version: 2.7.14

--- a/roles/anyenv/tasks/install/env.yml
+++ b/roles/anyenv/tasks/install/env.yml
@@ -1,13 +1,18 @@
 # workaround: http://qiita.com/tbuchi888/items/c03e7cbce8608b1c55f1
 
 - name: "install {{ env.name }}"
-  shell: "anyenv install {{ env.name }} --skip-existing"
+  shell: "source {{ bash_profile_dir }}/anyenv.sh; anyenv install {{ env.name }} --skip-existing"
+  changed_when: no
+
+- name: find env root
+  shell: "source {{ bash_profile_dir }}/anyenv.sh; {{ env.name }} root"
+  register: env_root
   changed_when: no
 
 - name: "install {{ env.name }} plugins"
   git:
     repo: "{{ plugin.repo }}"
-    dest: "{{ lookup('pipe', env.name + ' root') }}/plugins/{{ plugin.name }}"
+    dest: "{{ env_root.stdout }}/plugins/{{ plugin.name }}"
   with_items: "{{ env.plugins }}"
   loop_control:
     loop_var: plugin

--- a/roles/anyenv/tasks/install/env.yml
+++ b/roles/anyenv/tasks/install/env.yml
@@ -1,11 +1,19 @@
 # workaround: http://qiita.com/tbuchi888/items/c03e7cbce8608b1c55f1
 
 - name: "install {{ env.name }}"
-  shell: "source {{ bash_profile_dir }}/anyenv.sh; anyenv install {{ env.name }} --skip-existing"
+  shell: |
+    source {{ bash_profile_dir }}/anyenv.sh
+    anyenv install {{ env.name }} --skip-existing
+  args:
+    executable: /bin/bash
   changed_when: no
 
 - name: find env root
-  shell: "source {{ bash_profile_dir }}/anyenv.sh; {{ env.name }} root"
+  shell: |
+    source {{ bash_profile_dir }}/anyenv.sh
+    {{ env.name }} root
+  args:
+    executable: /bin/bash
   register: env_root
   changed_when: no
 

--- a/roles/anyenv/tasks/install/lang.yml
+++ b/roles/anyenv/tasks/install/lang.yml
@@ -1,10 +1,18 @@
 # workaround: http://qiita.com/tbuchi888/items/c03e7cbce8608b1c55f1
 
 - name: "install {{ lang.name }} {{ lang.version }}"
-  shell: "source {{ bash_profile_dir }}/anyenv.sh; {{ lang.env }} install {{ lang.version }} --skip-existing"
+  shell: |
+    source {{ bash_profile_dir }}/anyenv.sh
+    {{ lang.env }} install {{ lang.version }} --skip-existing
+  args:
+    executable: /bin/bash
   register: install
   changed_when: install.stdout != ''
 
 - name: "set global version of {{ lang.name }}"
-  shell: "source {{ bash_profile_dir }}/anyenv.sh; {{ lang.env }} global {{ lang.version }}"
+  shell: |
+    source {{ bash_profile_dir }}/anyenv.sh
+    {{ lang.env }} global {{ lang.version }}
+  args:
+    executable: /bin/bash
   changed_when: no

--- a/roles/anyenv/tasks/install/lang.yml
+++ b/roles/anyenv/tasks/install/lang.yml
@@ -1,10 +1,10 @@
 # workaround: http://qiita.com/tbuchi888/items/c03e7cbce8608b1c55f1
 
 - name: "install {{ lang.name }} {{ lang.version }}"
-  shell: "{{ lang.env }} install {{ lang.version }} --skip-existing"
+  shell: "source {{ bash_profile_dir }}/anyenv.sh; {{ lang.env }} install {{ lang.version }} --skip-existing"
   register: install
   changed_when: install.stdout != ''
 
 - name: "set global version of {{ lang.name }}"
-  shell: "{{ lang.env }} global {{ lang.version }}"
+  shell: "source {{ bash_profile_dir }}/anyenv.sh; {{ lang.env }} global {{ lang.version }}"
   changed_when: no

--- a/roles/anyenv/tasks/main.yml
+++ b/roles/anyenv/tasks/main.yml
@@ -1,3 +1,5 @@
+---
+
 - name: install anyenv
   git:
     repo: https://github.com/riywo/anyenv
@@ -41,7 +43,11 @@
 - name: set plugins of rbenv
   block:
     - name: "get path to rbenv root"
-      shell: "source {{ bash_profile_dir }}/anyenv.sh; rbenv root"
+      shell: |
+        source {{ bash_profile_dir }}/anyenv.sh
+        rbenv root
+      args:
+        executable: /bin/bash
       register: rbenv_root
       changed_when: no
 
@@ -69,5 +75,9 @@
       version: "{{ python2_version }}"
 
 - name: set Python versions
-  shell: "source {{ bash_profile_dir }}/anyenv.sh; pyenv global {{ python2_version }} {{ python_version }}"
+  shell: |
+    source {{ bash_profile_dir }}/anyenv.sh
+    pyenv global {{ python2_version }} {{ python_version }}
+  args:
+    executable: /bin/bash
   changed_when: no

--- a/roles/anyenv/tasks/main.yml
+++ b/roles/anyenv/tasks/main.yml
@@ -24,11 +24,6 @@
 
 # *env
 
-- name: reload env
-  import_role:
-    name: bash
-    tasks_from: source
-
 - name: install rbenv dependencies
   import_tasks: rbenv.yml
 
@@ -46,7 +41,7 @@
 - name: set plugins of rbenv
   block:
     - name: "get path to rbenv root"
-      shell: "rbenv root"
+      shell: "source {{ bash_profile_dir }}/anyenv.sh; rbenv root"
       register: rbenv_root
       changed_when: no
 
@@ -74,5 +69,5 @@
       version: "{{ python2_version }}"
 
 - name: set Python versions
-  shell: "pyenv global {{ python2_version }} {{ python_version }}"
+  shell: "source {{ bash_profile_dir }}/anyenv.sh; pyenv global {{ python2_version }} {{ python_version }}"
   changed_when: no


### PR DESCRIPTION
## 問題
`shell` module はそれぞれが sub-shell での実行のように動くから、前の `shell` の状態に依存しない。
これは素の `bash` で ENV なし環境を再現して確認した。

## Test
```shell
$ env -i bash --norc --noprofile
```

## 課題
長くなった

```yaml
  shell: |
    source some/env
    cmd --to run
  args:
    executable: /bin/bash
```

## ref
- https://stackoverflow.com/questions/9357464/how-to-start-a-shell-without-any-user-configuration